### PR TITLE
role: remove Ubuntu 18, add newer Distros

### DIFF
--- a/roles/caddy_server/README.md
+++ b/roles/caddy_server/README.md
@@ -9,9 +9,9 @@ Alternatively, you can also configure caddy with a Caddyfile by passing it to th
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu 18.04 LTS or newer
-  - Debian 10 or newer
-  - A CentOS 8-compatible distribution like RockyLinux or AlmaLinux. RockyLinux is used for testing
+  - Ubuntu: 20.04 LTS, 22.04 LTS
+  - Debian: 10, 11, 12
+  - RockyLinux: 8, 9
 - The following distributions are supported on a best-effort basis (should work but are not tested in CI):
   - Arch Linux
 - Supported architectures: Anything supported by upstream caddy should work

--- a/roles/caddy_server/molecule/caddyfile/molecule.yml
+++ b/roles/caddy_server/molecule/caddyfile/molecule.yml
@@ -3,10 +3,10 @@ platforms:
   # Note on containers:
   # - We use the images provided by geerlingguy, as they provide out-of-the-box
   #   support for Ansible and systemd (needed to test service management).
-  - name: caddy-ubuntu-20
+  - name: caddy-ubuntu-22
     groups:
       - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     systemd: always
     override_command: false
     pre_build_image: true
@@ -16,10 +16,20 @@ platforms:
     capabilities:
       - NET_ADMIN
 
-  - name: caddy-ubuntu-18
+  - name: caddy-ubuntu-20
     groups:
       - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    capabilities:
+      - NET_ADMIN
+
+  - name: caddy-debian-12
+    groups:
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     systemd: always
     override_command: false
     pre_build_image: true
@@ -40,6 +50,16 @@ platforms:
     groups:
       - debian
     image: "docker.io/geerlingguy/docker-debian10-ansible"
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    capabilities:
+      - NET_ADMIN
+
+  - name: caddy-rockylinux-9
+    groups:
+      - rockylinux
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
     systemd: always
     override_command: false
     pre_build_image: true

--- a/roles/caddy_server/molecule/default/molecule.yml
+++ b/roles/caddy_server/molecule/default/molecule.yml
@@ -3,10 +3,10 @@ platforms:
   # Note on containers:
   # - We use the images provided by geerlingguy, as they provide out-of-the-box
   #   support for Ansible and systemd (needed to test service management).
-  - name: caddy-ubuntu-20
+  - name: caddy-ubuntu-22
     groups:
       - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     systemd: always
     override_command: false
     pre_build_image: true
@@ -16,10 +16,20 @@ platforms:
     capabilities:
       - NET_ADMIN
 
-  - name: caddy-ubuntu-18
+  - name: caddy-ubuntu-20
     groups:
       - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    capabilities:
+      - NET_ADMIN
+
+  - name: caddy-debian-12
+    groups:
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     systemd: always
     override_command: false
     pre_build_image: true
@@ -46,6 +56,16 @@ platforms:
     capabilities:
       - NET_ADMIN
 
+  - name: caddy-rockylinux-9
+    groups:
+      - rockylinux
+    image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    capabilities:
+      - NET_ADMIN
+
   - name: caddy-rockylinux-8
     groups:
       - rockylinux
@@ -64,6 +84,8 @@ platforms:
     #   systemd: always
     #   override_command: false
     #   pre_build_image: true
+    #   capabilities:
+    #     - NET_ADMIN
 
 provisioner:
   playbooks:


### PR DESCRIPTION
Now that Ubuntu 18.04 LTS has reached its mainline EOL, we can drop it from the list of supported distributions. At the same time, Debian 12 and RockLinux 9 have been added to the distro list and the READMEs now explicitly list the supported versions to prevent confusion when new imcompatible major distro versions are released.
