### PR TITLE
bump ansible to 2.17, raise ninimum python to 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ workflows:
           parallelism: 3
           matrix:
             parameters:
-              ansible-version: ["2.15", "2.16"]
-              node-python-version: ["3.6"]
+              ansible-version: ["2.16", "2.17"]
+              node-python-version: ["3.7"]
       - collection-testing/pre-commit-lint:
           name: Lint
       - collection-testing/antsibull-docs:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An Ansible collection containing roles/modules to install, configure and interac
 
 - A recent release of Ansible. This collection officially supports the 2 most recent Ansible releases.
   Older versions might still work, but are not supported
-- Python 3.6 or newer on the target host
+- Python 3.7 or newer on the target host
 - The modules require the `requests` python module on the remote host
 
 Individual roles or modules may have additional dependencies, please check their respective documentation.

--- a/roles/caddy_server/README.md
+++ b/roles/caddy_server/README.md
@@ -9,9 +9,9 @@ Alternatively, you can also configure caddy with a Caddyfile by passing it to th
 ## Requirements
 
 - The following distributions are currently supported and tested:
-  - Ubuntu: 20.04 LTS, 22.04 LTS
+  - Ubuntu: 20.04 LTS, 22.04, 24.04 LTS
   - Debian: 10, 11, 12
-  - RockyLinux: 8, 9
+  - RockyLinux: 9
 - The following distributions are supported on a best-effort basis (should work but are not tested in CI):
   - Arch Linux
 - Supported architectures: Anything supported by upstream caddy should work

--- a/roles/caddy_server/molecule/caddyfile/molecule.yml
+++ b/roles/caddy_server/molecule/caddyfile/molecule.yml
@@ -1,8 +1,21 @@
 ---
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
+  - name: caddy-ubuntu-24
+    groups:
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    # Newer versions of the Caddy unit file use the NET_ADMIN capability,
+    # which is not passed by default. We explicitly enable it to ensure the services can start
+    # See: https://github.com/caddyserver/dist/pull/98
+    capabilities:
+      - NET_ADMIN
+
   - name: caddy-ubuntu-22
     groups:
       - ubuntu
@@ -13,9 +26,6 @@ platforms:
     privileged: true
     override_command: false
     pre_build_image: true
-    # Newer versions of the Caddy unit file use the NET_ADMIN capability,
-    # which is not passed by default. We explicitly enable it to ensure the services can start
-    # See: https://github.com/caddyserver/dist/pull/98
     capabilities:
       - NET_ADMIN
 
@@ -84,19 +94,6 @@ platforms:
     capabilities:
       - NET_ADMIN
 
-  - name: caddy-rockylinux-8
-    groups:
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    capabilities:
-      - NET_ADMIN
-
   # Only supported on a best effort-basis, CI is broken right now (2023-03-03)
   # - name: caddy-archlinux
   #   groups:
@@ -110,7 +107,6 @@ platforms:
   #   pre_build_image: true
   #   capabilities:
   #     - NET_ADMIN
-
 
 provisioner:
   playbooks:

--- a/roles/caddy_server/molecule/default/molecule.yml
+++ b/roles/caddy_server/molecule/default/molecule.yml
@@ -1,8 +1,21 @@
 ---
 platforms:
-  # Note on containers:
-  # - We use the images provided by geerlingguy, as they provide out-of-the-box
-  #   support for Ansible and systemd (needed to test service management).
+  - name: caddy-ubuntu-24
+    groups:
+      - ubuntu
+    image: "docker.io/geerlingguy/docker-ubuntu2404-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    # Newer versions of the Caddy unit file use the NET_ADMIN capability,
+    # which is not passed by default. We explicitly enable it to ensure the services can start
+    # See: https://github.com/caddyserver/dist/pull/98
+    capabilities:
+      - NET_ADMIN
+
   - name: caddy-ubuntu-22
     groups:
       - ubuntu
@@ -13,9 +26,6 @@ platforms:
     privileged: true
     override_command: false
     pre_build_image: true
-    # Newer versions of the Caddy unit file use the NET_ADMIN capability,
-    # which is not passed by default. We explicitly enable it to ensure the services can start
-    # See: https://github.com/caddyserver/dist/pull/98
     capabilities:
       - NET_ADMIN
 
@@ -75,19 +85,6 @@ platforms:
     groups:
       - rockylinux
     image: "docker.io/geerlingguy/docker-rockylinux9-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    capabilities:
-      - NET_ADMIN
-
-  - name: caddy-rockylinux-8
-    groups:
-      - rockylinux
-    image: "docker.io/geerlingguy/docker-rockylinux8-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,40 +1,18 @@
 # pylint: disable=redefined-outer-name
 
-from pathlib import Path
-
-from jinja2 import Environment, FileSystemLoader
-
-INTEGRATION_CONFIG_DIR = Path("tests/integration/")
-INTEGRATION_CONFIG_TEMPLATE = "integration_config.yml.j2"
-INTEGRATION_CONFIG_FILE = "integration_config.yml"
-
-
-def render_integration_config(template, dest: Path, **kwargs):
-    env = Environment(loader=FileSystemLoader(INTEGRATION_CONFIG_DIR))
-    template = env.get_template(template)
-    content = template.render(**kwargs)
-    with open(dest, "w", encoding="utf-8") as f:
-        f.write(f"{content}\n")
-
-
-def test_plugins_integration(test_versions, remote_caddy_container, collection_test_env):
-    render_integration_config(
-        INTEGRATION_CONFIG_TEMPLATE,
-        collection_test_env.cwd / "tests" / "integration" / INTEGRATION_CONFIG_FILE,
-        admin_url=remote_caddy_container.caddy_url,
-    )
-
-    collection_test_env.run([
-        "ansible-test", "integration", "--color", "-v",
-        "--controller", "docker:default",
-        "--target", f"docker:default,python={test_versions.node_python_version}",
-        "--docker-network", remote_caddy_container.ct_network,
-    ])
-
-
 def test_plugins_sanity(collection_test_env, test_versions):
-    collection_test_env.run([
+    params = [
         "ansible-test",
         "sanity", "--docker", "--color", "-v",
         "--python", test_versions.node_python_version,
-    ])
+    ]
+
+    if int(test_versions.ansible_version.split(".")[1]) <= 16:
+        # these flags are only valid with ansible-test 2.16 and older, as they refer to python 2.7.
+        # Do not include them with newer versions of ansible-test
+        params.extend([
+            "--skip-test", "metaclass-boilerplate",
+            "--skip-test", "future-import-boilerplate"
+        ])
+
+    collection_test_env.run(params)


### PR DESCRIPTION
With the ansible-2.17 release, python 2 and 3.6 have been removed
from the officially supported list. We therefore have to upgrade
our minimum tested version to 3.7, which is a breaking change,
even if we are not planning on breaking support ourselves.