### PR TITLE
caddy_server: remove support for Debian 10

### DIFF
--- a/roles/caddy_server/README.md
+++ b/roles/caddy_server/README.md
@@ -10,7 +10,7 @@ Alternatively, you can also configure caddy with a Caddyfile by passing it to th
 
 - The following distributions are currently supported and tested:
   - Ubuntu: 20.04 LTS, 22.04, 24.04 LTS
-  - Debian: 10, 11, 12
+  - Debian: 11, 12
   - RockyLinux: 9
 - The following distributions are supported on a best-effort basis (should work but are not tested in CI):
   - Arch Linux

--- a/roles/caddy_server/molecule/caddyfile/molecule.yml
+++ b/roles/caddy_server/molecule/caddyfile/molecule.yml
@@ -68,19 +68,6 @@ platforms:
     capabilities:
       - NET_ADMIN
 
-  - name: caddy-debian-10
-    groups:
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    capabilities:
-      - NET_ADMIN
-
   - name: caddy-rockylinux-9
     groups:
       - rockylinux

--- a/roles/caddy_server/molecule/default/molecule.yml
+++ b/roles/caddy_server/molecule/default/molecule.yml
@@ -68,19 +68,6 @@ platforms:
     capabilities:
       - NET_ADMIN
 
-  - name: caddy-debian-10
-    groups:
-      - debian
-    image: "docker.io/geerlingguy/docker-debian10-ansible"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    override_command: false
-    pre_build_image: true
-    capabilities:
-      - NET_ADMIN
-
   - name: caddy-rockylinux-9
     groups:
       - rockylinux


### PR DESCRIPTION
with the imminent end of LTS support, it's time to remove Debian 10
from testing to ease the load on our CI a little bit.