### PR TITLE
caddy_server: fix example playbook in README.

### DIFF
--- a/roles/caddy_server/README.md
+++ b/roles/caddy_server/README.md
@@ -98,6 +98,7 @@ This is done by overwriting the respective variables:
     - role: maxhoesel.caddy.caddy_server
       become: yes
       vars:
+        caddy_config_mode: Caddyfile
         caddy_caddyfile: |
             localhost:80
             respond "Hello, world!"


### PR DESCRIPTION
The second example lacks the option `caddy_config_mode` in order to work.

PS: Thank you very much for your work, Max!