### PR TITLE
Add Support for Debian 13, rework APT repository configuration

### DIFF
--- a/roles/caddy_server/README.md
+++ b/roles/caddy_server/README.md
@@ -10,7 +10,7 @@ Alternatively, you can also configure caddy with a Caddyfile by passing it to th
 
 - The following distributions are currently supported and tested:
   - Ubuntu: 22.04 LTS, 24.04 LTS
-  - Debian: 11, 12
+  - Debian: 11, 12, 13
   - RockyLinux: 9
 - The following distributions are supported on a best-effort basis (should work but are not tested in CI):
   - Arch Linux

--- a/roles/caddy_server/defaults/main.yml
+++ b/roles/caddy_server/defaults/main.yml
@@ -4,9 +4,9 @@ caddy_config_mode: json
 caddy_json_config: {}
 caddy_caddyfile: ""
 
-caddy_apt_repo: "https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main"
-caddy_apt_key: "https://dl.cloudsmith.io/public/caddy/stable/gpg.key"
-caddy_apt_keyring: "/usr/share/keyrings/caddy-stable-archive-keyring.gpg"
+caddy_apt_repo_url: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+caddy_apt_key_url: "https://dl.cloudsmith.io/public/caddy/stable/gpg.key"
+
 caddy_rpm_repo:
   "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{ 'fedora' if ansible_distribution | lower == 'fedora'
   else 'epel' }}-$releasever-$basearch/"

--- a/roles/caddy_server/molecule/default/molecule.yml
+++ b/roles/caddy_server/molecule/default/molecule.yml
@@ -29,6 +29,19 @@ platforms:
     capabilities:
       - NET_ADMIN
 
+  - name: caddy-debian-13
+    groups:
+      - debian
+    image: "docker.io/geerlingguy/docker-debian13-ansible"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    override_command: false
+    pre_build_image: true
+    capabilities:
+      - NET_ADMIN
+
   - name: caddy-debian-12
     groups:
       - debian

--- a/roles/caddy_server/tasks/install_debian.yml
+++ b/roles/caddy_server/tasks/install_debian.yml
@@ -1,15 +1,29 @@
 ---
-- name: Old apt-key trusted key is absent
+# This role previously used the old sources.list repository style with a separate key in the keyring.
+# This has been superseded by the deb822-based approach below, but we still need to clean up after ourselves.
+- name: Key is absent from old apt-key store
   ansible.builtin.apt_key:
     id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
     state: absent
-  register: old_install_present
+  when: >
+    ansible_distribution == "Debian" and ansible_distribution_major_version is version('12', '<=') or
+    ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<=')
+- name: Old repository definition is absent
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/dl_cloudsmith_io_public_caddy_stable_deb_debian.list
+    state: absent
 
-- name: APT Key is stored in keyring
-  ansible.builtin.apt_key:
-    url: "{{ caddy_apt_key }}"
-    keyring: "{{ caddy_apt_keyring }}"
+- name: Python3-debian package is present
+  ansible.builtin.apt:
+    name:
+      - python3-debian
 
-- name: Caddy repository is enabled
-  apt_repository:
-    repo: "deb [signed-by={{ caddy_apt_keyring }}] {{ caddy_apt_repo }}"
+- name: Caddy repository is configured
+  ansible.builtin.deb822_repository:
+    name: caddy-stable
+    uris: "{{ caddy_apt_repo_url }}"
+    types: ["deb", "deb-src"]
+    enabled: true
+    suites: "any-version"
+    components: ["main"]
+    signed_by: "{{ caddy_apt_key_url }}"


### PR DESCRIPTION
Debian 13 removed support for apt-key and recommends the deb822 format instead of the old one-line config style still used by upstream Caddy. This PR migrates our existing config to this new style using the new deb822_repository module built into Ansible.

BREAKING CHANGE: `caddy_apt_repo` and `caddy_apt_key` have been replaced with `caddy_apt_repo_url` and `caddy_apt_key_url` respectively. This was done since `caddy_apt_repo_url` is now only the plain repository URL instead of also containing suites and components.

Anyone using custom overrides should adjust their `caddy_apt_repo_url` value accordingly. Note that since the key is now stored inline in the list file, `caddy_apt_keyring` has been removed entirely.

Supersedes #231
