### PR TITLE
fix: use ansible_facts dict syntax for forward compatibility

### DIFF
--- a/roles/caddy_server/defaults/main.yml
+++ b/roles/caddy_server/defaults/main.yml
@@ -8,7 +8,7 @@ caddy_apt_repo_url: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
 caddy_apt_key_url: "https://dl.cloudsmith.io/public/caddy/stable/gpg.key"
 
 caddy_rpm_repo:
-  "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{ 'fedora' if ansible_distribution | lower == 'fedora'
+  "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{ 'fedora' if ansible_facts['distribution'] | lower == 'fedora'
   else 'epel' }}-$releasever-$basearch/"
 caddy_rpm_key: "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/pubkey.gpg"
 

--- a/roles/caddy_server/meta/argument_specs.yml
+++ b/roles/caddy_server/meta/argument_specs.yml
@@ -47,7 +47,7 @@ argument_specs:
       caddy_rpm_repo:
         description: "Url for the rpm repo"
         default:
-          "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{ 'fedora' if ansible_distribution | lower == 'fedora'
+          "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{ 'fedora' if ansible_facts['distribution'] | lower == 'fedora'
           else 'epel' }}-$releasever-$basearch/"
       caddy_rpm_key:
         description: "Url for the rpm repo gpg key"

--- a/roles/caddy_server/tasks/install.yml
+++ b/roles/caddy_server/tasks/install.yml
@@ -4,7 +4,7 @@
     name: "{{ caddy_server_packages }}"
 
 - name: Perform distro-specific install tasks
-  include_tasks: "install_{{ ansible_os_family | lower }}.yml"
+  include_tasks: "install_{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Caddy is installed
   package:

--- a/roles/caddy_server/tasks/install_debian.yml
+++ b/roles/caddy_server/tasks/install_debian.yml
@@ -6,8 +6,8 @@
     id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
     state: absent
   when: >
-    ansible_distribution == "Debian" and ansible_distribution_major_version is version('12', '<=') or
-    ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<=')
+    ansible_facts["distribution"] == "Debian" and ansible_facts["distribution_major_version"] is version('12', '<=') or
+    ansible_facts["distribution"] == "Ubuntu" and ansible_facts["distribution_version"] is version('24.04', '<=')
 - name: Old repository definition is absent
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/dl_cloudsmith_io_public_caddy_stable_deb_debian.list

--- a/roles/caddy_server/tasks/main.yml
+++ b/roles/caddy_server/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Load distribution-specific vars
-  ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Run Checks
   include_tasks: check.yml

--- a/roles/caddy_server/vars/debian.yml
+++ b/roles/caddy_server/vars/debian.yml
@@ -3,4 +3,4 @@ caddy_server_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-  - "{{ 'python3-requests' if ansible_python_version is version('3', '>=') else 'python-requests' }}"
+  - "{{ 'python3-requests' if ansible_facts['python_version'] is version('3', '>=') else 'python-requests' }}"

--- a/roles/caddy_server/vars/redhat.yml
+++ b/roles/caddy_server/vars/redhat.yml
@@ -1,3 +1,3 @@
 ---
 caddy_server_packages:
-  - "{{ 'python3-requests' if ansible_python_version is version('3', '>=') else 'python-requests' }}"
+  - "{{ 'python3-requests' if ansible_facts['python_version'] is version('3', '>=') else 'python-requests' }}"


### PR DESCRIPTION
## Summary
- Replace deprecated direct ansible fact variable access (`ansible_*`) with the `ansible_facts["*"]` dictionary syntax
- Resolves deprecation warnings in Ansible 2.20+ (ansible-core 2.24+)

## Problem
`INJECT_FACTS_AS_VARS` defaulting to `True` is deprecated and will be removed in ansible-core 2.24. Using facts like `ansible_distribution` directly causes deprecation warnings (my playbook used ansible-core 2.20 and Py3.14)

## Changes
- `ansible_distribution` → `ansible_facts["distribution"]`
- `ansible_distribution_major_version` → `ansible_facts["distribution_major_version"]`
- `ansible_distribution_version` → `ansible_facts["distribution_version"]`
- `ansible_os_family` → `ansible_facts["os_family"]`
- `ansible_python_version` → `ansible_facts["python_version"]`

## Test plan
- [x] All molecule tests pass locally (Python 3.12 - I used 3.12 because `ruamel-yaml-clib` doesn't support 3.14 yet)
- [x] Manually tested with my real workload playbook with Ansible 2.20.1 + Python 3.14 - deprecation warnings went away.

PS: Thanks in advance for such an amazing package, which has saved me many hours!