### PR TITLE
fix(caddyserver): path checks for being none instead of truthiness

### DIFF
--- a/plugins/module_utils/caddyserver.py
+++ b/plugins/module_utils/caddyserver.py
@@ -121,13 +121,13 @@ class CaddyServer(object):
             path (str): The path to create
         """
         segments = path.split("/")
-        if len(segments) == 0 or self.config_get(path):
+        if len(segments) == 0 or self.config_get(path) is not None:
             return
 
         present = []
         while len(segments) > 1:
             current_path = "/".join(present) + "/" + segments[0]
-            if not self.config_get(current_path):
+            if self.config_get(current_path) is None:
                 self.config_put("/".join(present) + "/" + segments[0],
                                 [] if segments[1].isdigit() else {}, create_path=False)
             present.append(segments[0])


### PR DESCRIPTION
Hello @maxhoesel,

Thank you very much for maintaining this role, it has been a lifesaver.

I would like to contribute back by fixing these two small truthiness checks. If you reset the caddy configuration to be fully empty to begin with, since it returns an `{}` or `[]` for certain paths, this truthiness check does not stop at the correct point.

```yaml
# my original caddy configuration is exactly like below
- name: load default configuration
  maxhoesel.caddy.caddy_config:
    state: present
    path: admin
    config:
      listen: :2019

- name: load acme configuration
  maxhoesel.caddy.caddy_config:
    state: present
    path: apps/tls/automation
    config:
      policies:
        - issuers:
            - module: acme
              challenges:
                dns:
                  provider:
                    name: cloudflare
                    api_token: '{{ lookup("community.hashi_vault.hashi_vault", "secret/data/legacy/caddy/cloudflare:token") }}'
                  resolvers:
                    - 1.1.1.1
```

```log
[ERROR]: Task failed: Module failed: Error durning processing of the request (Conflict): [/config/apps] key already exists: apps
Origin: -

7       listen: :2019
8
9 - name: load acme configuration
    ^ column 3

fatal: [trojan-loki]: FAILED! =>
    changed: false
    method: PUT
    msg: 'Error durning processing of the request (Conflict): [/config/apps] key already
        exists: apps'
    url: http://localhost:2019/config/apps
```